### PR TITLE
Use D2D factory to initialize D2D device

### DIFF
--- a/game/rendering/drawing/DrawingEngine.cpp
+++ b/game/rendering/drawing/DrawingEngine.cpp
@@ -25,7 +25,7 @@ DrawingEngine::DrawingEngine(const winrt::com_ptr<ID3D11Device>& d3dDevice, bool
 
   // Create a D2D device on top of the DXGI device
   winrt::com_ptr<ID2D1Device> d2dDevice;
-  winrt::check_hresult(D2D1CreateDevice(dxgiDevice.get(), nullptr, d2dDevice.put()));
+  winrt::check_hresult(_factory->CreateDevice(dxgiDevice.get(), d2dDevice.put()));
 
   // Get Direct2D device's corresponding device context object.
   winrt::check_hresult(

--- a/game/rendering/drawing/DrawingEngine.h
+++ b/game/rendering/drawing/DrawingEngine.h
@@ -95,6 +95,6 @@ class DrawingEngine {
 
   lru11::Cache<uint32_t, winrt::com_ptr<ID2D1SolidColorBrush>> _colorBrushCache;
 
-  winrt::com_ptr<ID2D1Factory> _factory;
+  winrt::com_ptr<ID2D1Factory1> _factory;
 
 };


### PR DESCRIPTION
Not using the factory to create the D2D device causes NVidia NSight to fail when trying to debug OT. This adjusts back to how TemplePlus initializes the D2D device, fixing this.